### PR TITLE
fix: change format startDate and endDate work experience from yyyy-mm…

### DIFF
--- a/src/app/module/public/service/public.service.impl.ts
+++ b/src/app/module/public/service/public.service.impl.ts
@@ -18,7 +18,7 @@ import {
   toArticleResponse,
 } from '@module/output/mapper'
 import { AppException } from '@core/exception/app.exception'
-import { cdnUrl } from '@shared/util/common.util'
+import { cdnUrl, formatDateToMonthYear } from '@shared/util/common.util'
 import { PublicService } from '@module/public/service/public.service'
 import { PdfService } from '@core/service/pdf.service'
 import { PortfolioDetailResponse } from '@module/portfolio/dto/portfolio.dto'
@@ -121,6 +121,12 @@ export class PublicServiceImpl implements PublicService {
 
   async generateCvAsPdf(username: string, locale: string): Promise<Buffer> {
     const publicData = await this.getPublicProfile(username)
+    publicData.experiences = publicData.experiences.map(experience => ({
+      ...experience,
+      startDate: formatDateToMonthYear(experience.startDate),
+      endDate: formatDateToMonthYear(experience.endDate ?? ''),
+    }))
+
     const t = await getTranslations(locale)
     const templateDate = {
       ...publicData,

--- a/src/app/shared/util/common.util.ts
+++ b/src/app/shared/util/common.util.ts
@@ -379,3 +379,14 @@ export function getYearFromDate(dateString: string | null | undefined): string {
     return dateString.substring(0, 4)
   }
 }
+
+export function formatDateToMonthYear(dateString: string): string {
+  if (!dateString) return ''
+
+  const date = new Date(dateString)
+
+  const month = date.toLocaleString('en-US', { month: 'short' })
+  const year = date.getFullYear()
+
+  return `${month} ${year}`
+}


### PR DESCRIPTION
…-dd to MonthName, Year

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date formatting in CV PDF generation. Work experience dates now display consistently in a month-year format (e.g., "Feb 2025") for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->